### PR TITLE
move table of contents to first page

### DIFF
--- a/discrete_mathematics.tex
+++ b/discrete_mathematics.tex
@@ -38,7 +38,8 @@ Committers : Aliaksei Kudzelka, Mykhailo Moroz, Mihail Orlov}
 
 \begin{document}
 \maketitle
-\cleardoublepage % Space for book title and committers
+\cleardoublepage % Space for book title and Committers
+\tableofcontents
 
 \section{Counting (Combinatorics)}
 Counting forms the basis of combinatorics. In these lectures we explore several counting rules, examples, and proofs.
@@ -67,10 +68,6 @@ Counting forms the basis of combinatorics. In these lectures we explore several 
 
 \section{Catalan Numbers}
 \includelectureSub{Catalan_Numbers}
-
-\newpage             % Forces a new page
-\tableofcontents
-\clearpage 
 
 \end{document}
 


### PR DESCRIPTION
I have moved the table of contents page to a more accessible location so it can be more useful to the reader.